### PR TITLE
Allow registering with existing Monkey ID

### DIFF
--- a/app/src/main/java/com/criptext/monkeychatandroid/RegisterActivity.java
+++ b/app/src/main/java/com/criptext/monkeychatandroid/RegisterActivity.java
@@ -7,9 +7,13 @@ import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.view.KeyEvent;
 import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ProgressBar;
+import android.widget.TextView;
 
 import com.criptext.ClientData;
 import com.criptext.lib.MonkeyInit;
@@ -21,14 +25,27 @@ import org.json.JSONObject;
 public class RegisterActivity extends AppCompatActivity {
 
     private SharedPreferences prefs;
-    private EditText editTextName;
+    private EditText editTextName, editTextId;
     private ProgressBar progressBar;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_register);
+        final Button submitBtn = (Button)findViewById(R.id.submitBtn);
+
         editTextName = (EditText)findViewById(R.id.editTextFullname);
+        editTextId = (EditText)findViewById(R.id.editTextMonkeyId);
+        editTextId.setOnEditorActionListener(new TextView.OnEditorActionListener() {
+            @Override
+            public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+                if(actionId == EditorInfo.IME_ACTION_DONE)
+                    submitBtn.performClick();
+                return false;
+            }
+        });
+
+
         progressBar = (ProgressBar) findViewById(R.id.progressBarCargando);
         prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
     }
@@ -37,6 +54,8 @@ public class RegisterActivity extends AppCompatActivity {
         v.setVisibility(View.GONE);
         progressBar.setVisibility(View.VISIBLE);
 
+        //userInfo stores any additional data about the user that we want to send to MonkeyKit.
+        //In this sample app we are only interested in the user's name
         JSONObject userInfo = new JSONObject();
         JSONArray ignore_params = new JSONArray();
         try {
@@ -45,7 +64,11 @@ public class RegisterActivity extends AppCompatActivity {
             e.printStackTrace();
         }
 
-        MonkeyInit mStart = new MonkeyInit(RegisterActivity.this, null,
+        String existingMonkeyId = editTextId.getText().toString();
+        if(existingMonkeyId.length() == 0)
+            existingMonkeyId = null;
+
+        MonkeyInit mStart = new MonkeyInit(RegisterActivity.this, existingMonkeyId,
                 SensitiveData.APP_ID, SensitiveData.APP_KEY, userInfo, ignore_params){
             @Override
             public void onSessionOK(String sessionID){

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -30,12 +30,28 @@
             android:layout_marginLeft="60dp"
             android:layout_marginRight="60dp"
             android:layout_marginTop="20dp"
+            android:layout_marginBottom="10dp"
+            android:maxLines="1"
+            android:gravity="center_horizontal"
+            android:maxLength="30"
+            android:hint="@string/fullname"
+            android:nextFocusDown="@+id/editTextMonkeyId"
+            android:inputType="text"/>
+
+        <EditText
+            android:id="@id/editTextMonkeyId"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="60dp"
+            android:layout_marginRight="60dp"
             android:layout_marginBottom="20dp"
             android:maxLines="1"
             android:maxLength="30"
+            android:hint="@string/monkeyId"
+            android:imeOptions="actionDone"
             android:inputType="text"/>
-
         <Button
+            android:id="@+id/submitBtn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/button_continuar"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,7 +2,9 @@
     <string name="app_name">MonkeyChatAndroid</string>
     <string name="chat_name">Monkey Chat Sample</string>
     <string name="register">Register to Monkey</string>
-    <string name="label_fullname">Enter your fullname</string>
+    <string name="label_fullname">Enter your data</string>
+    <string name="fullname">Full Name</string>
+    <string name="monkeyId">Monkey ID (Optional)</string>
     <string name="button_continuar">Continue</string>
     <string name="menu_deleteall">Delete all</string>
     <string name="new_group">New Group</string>

--- a/monkeyKit/src/main/java/com/criptext/http/MonkeyHttpClient.java
+++ b/monkeyKit/src/main/java/com/criptext/http/MonkeyHttpClient.java
@@ -57,12 +57,18 @@ public class MonkeyHttpClient {
         HttpResponse response = httpclient.execute(httppost);
         BufferedReader reader = new BufferedReader(new InputStreamReader(response.getEntity().getContent(), "UTF-8"));
         String json = reader.readLine();
-        Log.d("Response","json " + json);
-        if(json.equals("Unauthorized")){
-            throw new IllegalArgumentException("Server response: Unauthorized\n Please check your APP_ID and APP_KEY");
+        //Log.d("Response","json " + json + " status: " + response.getStatusLine().getStatusCode());
+        switch(response.getStatusLine().getStatusCode()){
+            case 200:
+                JSONTokener tokener = new JSONTokener(json);
+                return new JSONObject(tokener);
+            case 403:
+                throw new IllegalArgumentException(json);
+            case 401:
+                throw new IllegalArgumentException("Server response: Unauthorized\n Please check your APP_ID and APP_KEY");
+
         }
-        JSONTokener tokener = new JSONTokener(json);
-        return new JSONObject(tokener);
+        return null;
     }
 
     public static void subscribePushHttp(String token, String sessionId, String urlUser, String urlPass, boolean override) throws JSONException,


### PR DESCRIPTION
the register activity has been modified to include an additional EditText for
MonkeyID to use instead of generating a new one.

Better handling of keyboard events on register activity

Use status codes for error handling in MonkeyInit
