### PR TITLE
Use ID and timestamp to update DLed messages

### DIFF
--- a/app/src/main/java/com/criptext/monkeychatandroid/ChatDataFragment.java
+++ b/app/src/main/java/com/criptext/monkeychatandroid/ChatDataFragment.java
@@ -10,12 +10,13 @@ import com.criptext.monkeykitui.recycler.MonkeyItem;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Created by gesuwall on 8/17/16.
  */
 public class ChatDataFragment extends Fragment{
-    HashMap<String, Collection<MonkeyItem>> chatMap;
+    HashMap<String, List<MonkeyItem>> chatMap;
     Collection<MonkeyConversation> conversationsList;
     MessageLoader messageLoader;
     GroupData groupData;

--- a/app/src/main/java/com/criptext/monkeychatandroid/MainActivity.java
+++ b/app/src/main/java/com/criptext/monkeychatandroid/MainActivity.java
@@ -37,6 +37,7 @@ import com.criptext.monkeykitui.input.listeners.InputListener;
 import com.criptext.monkeykitui.recycler.ChatActivity;
 import com.criptext.monkeykitui.recycler.GroupChat;
 import com.criptext.monkeykitui.recycler.MonkeyItem;
+import com.criptext.monkeykitui.recycler.MonkeyItemTransaction;
 import com.criptext.monkeykitui.recycler.audio.DefaultVoiceNotePlayer;
 import com.criptext.monkeykitui.recycler.audio.VoiceNotePlayer;
 import com.criptext.monkeykitui.util.MonkeyFragmentManager;
@@ -52,6 +53,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 import io.realm.Realm;
@@ -65,8 +67,9 @@ public class MainActivity extends MKDelegateActivity implements ChatActivity, Co
     MonkeyFragmentManager monkeyFragmentManager;
 
     MonkeyChatFragment monkeyChatFragment;
+
     MonkeyConversationsFragment monkeyConversationsFragment;
-    HashMap<String, Collection<MonkeyItem>> messagesMap = new HashMap<>();
+    HashMap<String, List<MonkeyItem>> messagesMap = new HashMap<>();
     Collection<MonkeyConversation> conversationsList = null;
     ChatDataFragment dataFragment;
     /**
@@ -166,7 +169,7 @@ public class MainActivity extends MKDelegateActivity implements ChatActivity, Co
         final ChatDataFragment retainedFragment =(ChatDataFragment) getSupportFragmentManager().findFragmentByTag(DATA_FRAGMENT);
         if(retainedFragment != null) {
             messageLoader = retainedFragment.messageLoader;
-            messagesMap = retainedFragment.chatMap!=null?retainedFragment.chatMap:new HashMap<String, Collection<MonkeyItem>>();
+            messagesMap = retainedFragment.chatMap!=null?retainedFragment.chatMap:new HashMap<String, List<MonkeyItem>>();
             conversationsList = retainedFragment.conversationsList;
             groupData = retainedFragment.groupData;
             if (monkeyChatFragment != null) {
@@ -348,7 +351,7 @@ public class MainActivity extends MKDelegateActivity implements ChatActivity, Co
      * @param newStatus new status to change
      */
     private void updateMessage(String id, MonkeyItem.DeliveryStatus newStatus) {
-        DatabaseHandler.updateMessageOutgoingStatus(realm, id, newStatus);
+        //DatabaseHandler.updateMessageOutgoingStatus(realm, id, newStatus);
         if (monkeyChatFragment != null) {
             MessageItem monkeyItem = (MessageItem) monkeyChatFragment.findMonkeyItemById(id);
             if (monkeyItem != null) {
@@ -358,6 +361,31 @@ public class MainActivity extends MKDelegateActivity implements ChatActivity, Co
         }
     }
 
+    private void updateMessage(String id, long dateorder, String conversationId, final MonkeyItem.DeliveryStatus newStatus) {
+        MonkeyItemTransaction transaction = new MonkeyItemTransaction() {
+                @Override
+                public MonkeyItem invoke(MonkeyItem monkeyItem) {
+                    MessageItem message = (MessageItem) monkeyItem;
+                    message.setStatus(newStatus);
+                    return message;
+                }
+            };
+
+        if (monkeyChatFragment != null && monkeyChatFragment.getConversationId().equals(conversationId)) {
+            //If conversation is currently open
+            monkeyChatFragment.updateMessage(id, dateorder, transaction);
+        } else {
+            //Look for the conversation
+            List<MonkeyItem> conversationMessages = messagesMap.get(conversationId);
+            if(conversationMessages != null){
+                int position = MonkeyItem.Companion.findItemPositionInList(id, dateorder, conversationMessages);
+                if(position > -1){
+                    MonkeyItem updateItem = conversationMessages.remove(position);
+                    conversationMessages.add(position, transaction.invoke(updateItem));
+                }
+            }
+        }
+    }
     /**
      * Update a conversation according to the params received.
      * @param conversationId conversation id to change
@@ -595,9 +623,10 @@ public class MainActivity extends MKDelegateActivity implements ChatActivity, Co
     }
 
     @Override
-    public void onFileDownloadFinished(String fileMessageId, boolean success) {
+    public void onFileDownloadFinished(String fileMessageId, long fileMessageTimestamp,
+                                       String conversationId, boolean success) {
         //TODO use better search algorithm
-        super.onFileDownloadFinished(fileMessageId, success);
+        super.onFileDownloadFinished(fileMessageId, fileMessageTimestamp, conversationId, success);
         updateMessage(fileMessageId,
                 success ? MonkeyItem.DeliveryStatus.delivered : MonkeyItem.DeliveryStatus.error);
     }
@@ -908,13 +937,17 @@ public class MainActivity extends MKDelegateActivity implements ChatActivity, Co
     public void onFileDownloadRequested(@NotNull MonkeyItem item) {
 
         if(item.getDeliveryStatus() == MonkeyItem.DeliveryStatus.error) {
+            //If the message failed to download previously, mark it as sending and rebind.
+            //Rebinding will update the UI to a loading view and call this method again to start
+            //the download
             updateMessage(item.getMessageId(), MonkeyItem.DeliveryStatus.sending);
             if(monkeyChatFragment != null)
                 monkeyChatFragment.rebindMonkeyItem(item);
-        } else {
+        } else { //Not error status, download the file.
             final MessageItem messageItem = (MessageItem) item;
             downloadFile(messageItem.getMessageId(), messageItem.getFilePath(),
-                    messageItem.getProps(), messageItem.getContactSessionId());
+                    messageItem.getProps(), messageItem.getContactSessionId(),
+                    messageItem.getMessageTimestampOrder(), getActiveConversation());
         }
 
     }
@@ -939,7 +972,7 @@ public class MainActivity extends MKDelegateActivity implements ChatActivity, Co
 
     @NotNull
     @Override
-    public Collection<MonkeyItem> getInitialMessages(String conversationId) {
+    public List<MonkeyItem> getInitialMessages(String conversationId) {
         myFriendID = conversationId;
         if(messagesMap.get(conversationId).size() < messageLoader.getPageSize())
             addOldMessagesFromServer(conversationId);
@@ -958,14 +991,14 @@ public class MainActivity extends MKDelegateActivity implements ChatActivity, Co
     }
 
     @Override
-    public void retainMessages(@NotNull String conversationId, @NotNull Collection<? extends MonkeyItem> messages) {
+    public void retainMessages(@NotNull String conversationId, @NotNull List<? extends MonkeyItem> messages) {
         if(messagesMap!=null)
-            messagesMap.put(conversationId, (Collection<MonkeyItem>) messages);
+            messagesMap.put(conversationId, (List<MonkeyItem>) messages);
     }
 
     @Override
-    public void retainConversations(@NotNull Collection<? extends MonkeyConversation> conversations) {
-        conversationsList = (Collection<MonkeyConversation>)conversations;
+    public void retainConversations(@NotNull List<? extends MonkeyConversation> conversations) {
+        conversationsList = (List<MonkeyConversation>)conversations;
     }
 
     @Override

--- a/app/src/main/java/com/criptext/monkeychatandroid/MyFileUploadService.java
+++ b/app/src/main/java/com/criptext/monkeychatandroid/MyFileUploadService.java
@@ -29,7 +29,7 @@ public class MyFileUploadService extends MonkeyFileService{
     }
 
     @Override
-    public void onFileDownloadFinished(@NotNull String messageId, boolean error) {
+    public void onFileDownloadFinished(@NotNull String messageId, @NotNull String conversationId, boolean error) {
         Realm realm = MonkeyChat.getInstance().getNewMonkeyRealm();
         realm.beginTransaction();
         DatabaseHandler.updateMessageOutgoingStatusBlocking(realm, messageId,

--- a/monkeyKit/src/main/java/com/criptext/MonkeyKitSocketService.kt
+++ b/monkeyKit/src/main/java/com/criptext/MonkeyKitSocketService.kt
@@ -104,12 +104,27 @@ abstract class MonkeyKitSocketService : Service() {
 
     internal var receiver : ConnectionChangeReceiver? = null
 
-    fun downloadFile(fileMessageId: String, fileName: String, props: String, monkeyId: String){
+    /**
+     * Starts MonkeyFileService to download a file. once the download is finished. the
+     * onFileDownloadFinished callback is executed.
+     * @param fileMessageId the ID of the message to download
+     * @param fileName The file to download's name
+     * @param props A JSON encoded string with the messages props
+     * @param monkeyId the monkey ID of the user that originally sent this file
+     * @param sortdate the timestamp used for sorting the messages.
+     * @param conversationId a unique identifier of the conversation to while the downloaded message
+     * belongs to.
+     *
+     */
+    fun downloadFile(fileMessageId: String, fileName: String, props: String, monkeyId: String,
+                     sortdate: Long, conversationId: String){
         val intent = Intent(this, uploadServiceClass)
         intent.putExtra(MOKMessage.MSG_KEY, fileName)
         intent.putExtra(MOKMessage.PROPS_KEY, props)
         intent.putExtra(MOKMessage.SID_KEY, monkeyId)
         intent.putExtra(MOKMessage.ID_KEY, fileMessageId)
+        intent.putExtra(MOKMessage.DATESORT_KEY, sortdate)
+        intent.putExtra(MOKMessage.CONVERSATION_KEY, conversationId)
         intent.putExtra(MonkeyFileService.ISUPLOAD_KEY, false)
         intent.putExtra(MonkeyFileService.APPID_KEY, clientData.appId)
         intent.putExtra(MonkeyFileService.APPKEY_KEY, clientData.appKey)
@@ -318,7 +333,8 @@ abstract class MonkeyKitSocketService : Service() {
                 delegate?.onAddGroupMember(info[0] as String, info[1] as String?, info[2] as Exception?)
             }
             CBTypes.onFileDownloadFinished -> {
-                delegate?.onFileDownloadFinished(info[0] as String, info[1] as Boolean)
+                delegate?.onFileDownloadFinished(info[0] as String, info[1] as Long, info[2] as String,
+                        info[3] as Boolean)
             }
             CBTypes.onContactOpenMyConversation -> {
                 delegate?.onContactOpenMyConversation(info[0] as String)

--- a/monkeyKit/src/main/java/com/criptext/comunication/FileBroadcastReceiver.kt
+++ b/monkeyKit/src/main/java/com/criptext/comunication/FileBroadcastReceiver.kt
@@ -31,8 +31,10 @@ class FileBroadcastReceiver(val service: MonkeyKitSocketService) : BroadcastRece
              }
              MonkeyFileService.DOWNLOAD_ACTION -> {
                  val msgId = intent.getStringExtra(MOKMessage.ID_KEY)
+                 val timeorder = intent.getLongExtra(MOKMessage.DATESORT_KEY, 0L)
+                 val convId = intent.getStringExtra(MOKMessage.CONVERSATION_KEY)
                  service.processMessageFromHandler(CBTypes.onFileDownloadFinished,
-                         arrayOf(msgId, response != null))
+                         arrayOf(msgId, timeorder, convId, response != null))
 
              }
          }

--- a/monkeyKit/src/main/java/com/criptext/comunication/MOKMessage.kt
+++ b/monkeyKit/src/main/java/com/criptext/comunication/MOKMessage.kt
@@ -103,5 +103,7 @@ class MOKMessage(var message_id: String,var sid: String,var rid: String,var msg:
         val TYPE_KEY = "MOKMessage.type"
         val PARAMS_KEY = "MOKMessage.params"
         val PROPS_KEY = "MOKMessage.props"
+        val DATESORT_KEY = "MOKMessage.datetimeorder"
+        val CONVERSATION_KEY = "MOKMessage.conversationID"
     }
 }

--- a/monkeyKit/src/main/java/com/criptext/lib/MKDelegateActivity.kt
+++ b/monkeyKit/src/main/java/com/criptext/lib/MKDelegateActivity.kt
@@ -13,6 +13,7 @@ import com.criptext.comunication.PushMessage
 import com.criptext.security.RandomStringBuilder
 import com.google.gson.JsonObject
 import org.apache.commons.io.FilenameUtils
+import java.security.Timestamp
 import java.util.*
 
 abstract class MKDelegateActivity : AppCompatActivity(), MonkeyKitDelegate {
@@ -193,7 +194,8 @@ abstract class MKDelegateActivity : AppCompatActivity(), MonkeyKitDelegate {
         sentFile?.failed = true
     }
 
-    override fun onFileDownloadFinished(fileMessageId: String, success: Boolean) {
+    override fun onFileDownloadFinished(fileMessageId: String, fileMessageTimestamp: Long,
+                                        conversationId: String, success: Boolean) {
         pendingDownloads.remove(fileMessageId)
     }
 
@@ -233,10 +235,15 @@ abstract class MKDelegateActivity : AppCompatActivity(), MonkeyKitDelegate {
      * @param filepath the absolute path where the downloaded file should be stored.
      * @param props the props JsonObject of the file message to download
      * @param senderId the monkey ID of the user who sent this file message
+     * @param conversationId an identifier of the conversation to which the download message belongs to
+     * This will be used in the onDownloadFinished callback so that you can easily search for your
+     * message and update it
      */
-    fun downloadFile(fileMessageId: String, filepath: String, props: JsonObject, senderId: String){
+    fun downloadFile(fileMessageId: String, filepath: String, props: JsonObject, senderId: String,
+                     sortdate: Long, conversationId: String){
         if(!pendingDownloads.containsKey(filepath)){
-            service?.downloadFile(fileMessageId, filepath, props.toString(), senderId)
+            service?.downloadFile(fileMessageId, filepath, props.toString(), senderId,
+                    sortdate, conversationId)
 
             pendingDownloads.put(filepath, DownloadMessage(fileMessageId, filepath, props))
         }
@@ -320,7 +327,8 @@ abstract class MKDelegateActivity : AppCompatActivity(), MonkeyKitDelegate {
             socketService?.getUserInfoById(conversationId)
     }
 
-    private data class DownloadMessage(val fileMessageId: String, val filepath: String, val props: JsonObject)
+    private data class DownloadMessage(val fileMessageId: String, val filepath: String,
+                                       val props: JsonObject)
     companion object{
         val  CONNECTION_NOT_READY_ERROR = "MonkeyKitSocketService is not ready yet."
     }

--- a/monkeyKit/src/main/java/com/criptext/lib/MonkeyKitDelegate.kt
+++ b/monkeyKit/src/main/java/com/criptext/lib/MonkeyKitDelegate.kt
@@ -36,10 +36,15 @@ interface MonkeyKitDelegate {
      * With this callback you should update your UI to show an error message or a download
      * complete message, depending on the result.
      * @param fileMessageId The downloaded file's message id
+     * @param fileMessageTimestamp Unique identiffier of the downloaded file's conversation, this
+     * might make it easier to search for the message.
+     * @param fileMessageTimestamp The downloaded file's timestamp, this might make it easier to
+     * search for the message.
      * *
      * @param success true if the file was successfully downloaded, otherwise false
      */
-    fun onFileDownloadFinished(fileMessageId: String, success: Boolean)
+    fun onFileDownloadFinished(fileMessageId: String, fileMessageTimestamp: Long,
+                               conversationId: String, success: Boolean)
 
     /**
      * After create a group with createGroup method, the server responds with the group ID


### PR DESCRIPTION
To download messages you must now pass the message's conversation ID and sorting
timestamp along with the message ID and sender ID. This change was made so that
you can get back this data on the onFileDownloadFinished callback for easier
message searching.
On MainActivity, when a file is downloaded completely, the conversation ID is
used to check if the active conversation is where the message belongs. If it
does, then let the Chatfragment update it. Otherwise look for in the chatMap and
update.

ChatMap now holds Lists instead of collections.
