### PR TITLE
set correct badge on new conversations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     compile 'com.michaelpardo:activeandroid:3.1.0-SNAPSHOT'
     compile project(':monkeyKit')
     //compile project(':monkeykitui')
-    compile 'com.github.Criptext:Monkey-UI-Android:98ddcc6237'
+    compile 'com.github.Criptext:MonkeyUIAndroid:9f448d3c5b'
     compile('com.crashlytics.sdk.android:crashlytics:2.6.5@aar') {
         transitive = true;
     }

--- a/app/src/main/java/com/criptext/monkeychatandroid/models/AsyncDBHandler.java
+++ b/app/src/main/java/com/criptext/monkeychatandroid/models/AsyncDBHandler.java
@@ -21,7 +21,22 @@ public class AsyncDBHandler {
            task.cancel(true);
         }
     }
-
+    public void storeNewConversation(final StoreNewConversationTask.OnQueryReturnedListener listener,
+                                     ConversationItem params){
+        final StoreNewConversationTask newTask = new StoreNewConversationTask();
+        pendingTasks.add(newTask);
+        StoreNewConversationTask.OnQueryReturnedListener trueListener = new StoreNewConversationTask.OnQueryReturnedListener() {
+            @Override
+            public void onQueryReturned(ConversationItem result) {
+                pendingTasks.remove(newTask);
+                if(listener != null){
+                    listener.onQueryReturned(result);
+                }
+            }
+        };
+        newTask.onQueryReturnedListener = trueListener;
+        newTask.execute(params);
+    }
     public void getConversationById(final FindConversationTask.OnQueryReturnedListener listener, String... params){
         final FindConversationTask newTask = new FindConversationTask();
         pendingTasks.add(newTask);

--- a/app/src/main/java/com/criptext/monkeychatandroid/models/DatabaseHandler.java
+++ b/app/src/main/java/com/criptext/monkeychatandroid/models/DatabaseHandler.java
@@ -278,15 +278,20 @@ public class DatabaseHandler {
         new SaveModelTask().execute(conversation);
     }
 
+    public static List<MessageItem> getAllMessagesSince(String conversationId, long since) {
+        Log.d("allMessagesSince", "" + since);
+        return new Select().from(MessageItem.class)
+                    .where("conversationId = ?", conversationId)
+                    .where("isIncoming = ?", true)
+                    .where("timestampOrder > ?", since).execute();
+    }
+
 
     public static void syncConversation(String id){
         ConversationItem conversation = getConversationById(id);
         if(conversation != null) {
             /*TODO don't calcuate the totalNewMessages value counting the unread messages in the local DB */
-            List<MessageItem> unreadMessages = new Select().from(MessageItem.class)
-                    .where("conversationId = ?", id)
-                    .where("isIncoming = ?", true)
-                    .where("timestampOrder > ?", conversation.lastOpen).execute();
+            List<MessageItem> unreadMessages = getAllMessagesSince(conversation.getConvId(), conversation.lastOpen);
             int unreadMessageCount = unreadMessages.size();
             conversation.setTotalNewMessage(unreadMessageCount);
             MessageItem lastMessage;
@@ -327,9 +332,9 @@ public class DatabaseHandler {
         new Delete().from(ConversationItem.class).where("idConv = ?", conversationId).execute();
     }
 
-    public static String getSecondaryTextByMessageType(MonkeyItem monkeyItem){
+    public static String getSecondaryTextByMessageType(MonkeyItem monkeyItem, boolean isGroup){
         if(monkeyItem == null)
-            return "Write to Contact";
+            return isGroup ? "Write to group" : "Write to contact";
         switch (MonkeyItem.MonkeyItemType.values()[monkeyItem.getMessageType()]) {
             case audio:
                 return "Audio";

--- a/app/src/main/java/com/criptext/monkeychatandroid/models/StoreNewConversationTask.java
+++ b/app/src/main/java/com/criptext/monkeychatandroid/models/StoreNewConversationTask.java
@@ -1,0 +1,64 @@
+package com.criptext.monkeychatandroid.models;
+
+import android.os.AsyncTask;
+import android.provider.ContactsContract;
+import android.util.Log;
+
+import com.activeandroid.ActiveAndroid;
+import com.criptext.monkeykitui.conversation.MonkeyConversation;
+
+import java.util.List;
+
+/**
+ * Stores a new conversation in background, querying the database for existing unread messages
+ * to set data such as totalNewMessages and lastMessageText. This assumes that the local DB has
+ * all the possible unread messages of the conversation. This task should be executed after the
+ * onUserInfo callback, which should have been triggered after receiving one or more messages
+ * from an unexistant conversation.
+ * Created by Gabriel on 10/20/16.
+ */
+public class StoreNewConversationTask extends AsyncTask<ConversationItem, Void, ConversationItem> {
+    public OnQueryReturnedListener onQueryReturnedListener = null;
+
+    public StoreNewConversationTask(){
+    }
+
+    public StoreNewConversationTask(OnQueryReturnedListener listener){
+        onQueryReturnedListener = listener;
+    }
+
+    @Override
+    protected ConversationItem doInBackground(ConversationItem... params) {
+        ConversationItem conv = params[0];
+        ActiveAndroid.beginTransaction();
+        try {
+            List<MessageItem> messages = DatabaseHandler.getAllMessagesSince(conv.getConvId(), conv.lastOpen);
+            conv.setTotalNewMessage(messages.size());
+            if (!messages.isEmpty()) {
+                MessageItem lastMessage = messages.get(messages.size() - 1);
+                conv.setSecondaryText(DatabaseHandler.getSecondaryTextByMessageType(lastMessage, conv.isGroup()));
+                conv.setStatus(MonkeyConversation.ConversationStatus.receivedMessage.ordinal());
+            }
+            conv.save();
+            ActiveAndroid.setTransactionSuccessful();
+            return conv;
+        } finally {
+            ActiveAndroid.endTransaction();
+        }
+    }
+
+    @Override
+    protected void onCancelled() {
+        onQueryReturnedListener = null;
+    }
+
+    @Override
+    protected void onPostExecute(ConversationItem conversationItem) {
+        if(onQueryReturnedListener != null)
+            onQueryReturnedListener.onQueryReturned(conversationItem);
+    }
+
+    public interface OnQueryReturnedListener {
+        void onQueryReturned(ConversationItem result);
+    }
+}


### PR DESCRIPTION
When creating new conversations after the response of getUserInfo() or
getGroupInfo() the local database is queried to retrieve the
totalNewMessages and secondary text. The badge is now displayed more
accurately.

The acknowledge of read messages is now processed correctly. instead of
updating messages in the database, just update the lastRead value of the
MonkeyAdapter.

Use UI Kit 9f448d3c5b
