### PR TITLE
Delete getSecondaryTextByMessageType function

### DIFF
--- a/app/src/main/java/com/criptext/monkeychatandroid/MainActivity.java
+++ b/app/src/main/java/com/criptext/monkeychatandroid/MainActivity.java
@@ -478,13 +478,10 @@ public class MainActivity extends MKDelegateActivity implements ChatActivity, Co
         unsend working with messages
      */
     private void updateConversationLastRead(final String convId, final long lastRead){
-        Log.d("MainActivity", "updateConversation last read");
         asyncDBHandler.getConversationById(new FindConversationTask.OnQueryReturnedListener() {
             @Override
             public void onQueryReturned(ConversationItem result) {
                 if(result != null){
-
-                    Log.d("MainActivity", "updateConversation last read found " + result.getSecondaryText() + " " + result.getTotalNewMessages());
                     ConversationTransaction transaction = new ConversationTransaction() {
                         @Override
                         public void updateConversation(MonkeyConversation monkeyConversation) {
@@ -531,7 +528,7 @@ public class MainActivity extends MKDelegateActivity implements ChatActivity, Co
                         transaction.updateConversation(result);
 
                     DatabaseHandler.updateConversationWithSentMessage(result,
-                            MessageItem.getSecondaryTextByMessageType(message),
+                            DatabaseHandler.getSecondaryTextByMessageType(message, result.isGroup()),
                             read ? MonkeyConversation.ConversationStatus.sentMessageRead
                                     : MonkeyConversation.ConversationStatus.deliveredMessage, 0);
                 }
@@ -1201,7 +1198,7 @@ public class MainActivity extends MKDelegateActivity implements ChatActivity, Co
                     lastMessage.getMessageTimestamp() <= conversationItem.lastRead){
                 status = MonkeyConversation.ConversationStatus.sentMessageRead;
             }
-            updateConversation(lastMessage.getConversationId(), MessageItem.getSecondaryTextByMessageType(lastMessage),
+            updateConversation(lastMessage.getConversationId(), DatabaseHandler.getSecondaryTextByMessageType(lastMessage, conversationItem.isGroup()),
                     status, unreadCounter > 0 ? -1 : 0, lastMessage.getMessageTimestampOrder(), 0);
 
             return;

--- a/app/src/main/java/com/criptext/monkeychatandroid/models/DatabaseHandler.java
+++ b/app/src/main/java/com/criptext/monkeychatandroid/models/DatabaseHandler.java
@@ -1,6 +1,7 @@
 package com.criptext.monkeychatandroid.models;
 
 import android.content.Context;
+import android.provider.ContactsContract;
 import android.util.Log;
 
 import com.activeandroid.ActiveAndroid;
@@ -306,7 +307,7 @@ public class DatabaseHandler {
                     secondaryText = "Write to this group";
                 conversation.setSecondaryText(secondaryText);
             } else {
-                conversation.setSecondaryText(MessageItem.getSecondaryTextByMessageType(lastMessage));
+                conversation.setSecondaryText(DatabaseHandler.getSecondaryTextByMessageType(lastMessage, conversation.isGroup()));
                 conversation.setDatetime(lastMessage.getMessageTimestampOrder());
 
                 if (lastMessage.isIncomingMessage())

--- a/app/src/main/java/com/criptext/monkeychatandroid/models/MessageItem.java
+++ b/app/src/main/java/com/criptext/monkeychatandroid/models/MessageItem.java
@@ -203,14 +203,4 @@ public class MessageItem extends Model implements MonkeyItem, Comparable<Message
             return 0;
     }
 
-    public static String getSecondaryTextByMessageType(MonkeyItem monkeyItem){
-        switch (MonkeyItem.MonkeyItemType.values()[monkeyItem.getMessageType()]) {
-            case audio:
-                return "Audio";
-            case photo:
-                return "Photo";
-            default:
-                return monkeyItem.getMessageText();
-        }
-    }
 }


### PR DESCRIPTION
This function is already implemented in DatabaseHandler. Delete the method in
MessageItem.
